### PR TITLE
eventlet.green.zmq compatibility

### DIFF
--- a/zmqpy/__init__.py
+++ b/zmqpy/__init__.py
@@ -2,4 +2,5 @@ from .zmqpy import *
 from .constants import *
 from .error import *
 
-__all__ = ['zmqpy', 'constants', 'error']
+__all__ = (['zmqpy', 'constants', 'error'] +
+           zmqpy.__all__ + constants.__all__ + error.__all__)

--- a/zmqpy/error.py
+++ b/zmqpy/error.py
@@ -1,9 +1,11 @@
 import zmqpy
 from ctypes import get_errno
 
+__all__ = ['ZMQError']
+
 class ZMQError(Exception):
-    def __init__(self, _errno=0):
-        if not _errno:
-            self._errno = get_errno()
+    def __init__(self, errno=0):
+        if not errno:
+            self.errno = get_errno()
         else:
-            self._errno = _errno
+            self.errno = errno

--- a/zmqpy/tests/pyzmq_tests/__init__.py
+++ b/zmqpy/tests/pyzmq_tests/__init__.py
@@ -69,8 +69,8 @@ class BaseZMQTestCase(TestCase):
         try:
             func(*args, **kwargs)
         except zmq.ZMQError as e:
-            self.assertEqual(e._errno, errno, "wrong error raised, \ expected '%s' \
-got '%s'" % (zmq.ZMQError(errno), zmq.ZMQError(e._errno)))
+            self.assertEqual(e.errno, errno, "wrong error raised, \ expected '%s' \
+got '%s'" % (zmq.ZMQError(errno), zmq.ZMQError(e.errno)))
         else:
             self.fail("Function did not raise any error")
 

--- a/zmqpy/zmqpy.py
+++ b/zmqpy/zmqpy.py
@@ -16,6 +16,8 @@ from .error import *
 from .utils import jsonapi
 from .utils.strtypes import bytes, unicode
 
+__all__ = ['Context', 'select', 'Socket', 'zmq_version', 'Poller']
+
 class Context(object):
     _state = {}
     def __init__(self, iothreads=1):
@@ -211,7 +213,7 @@ class Socket(object):
 
         if ret < 0:
             C.zmq_msg_close(zmq_msg)
-            raise zmqpy.ZMQError(_errno=C.zmq_errno())
+            raise ZMQError(errno=C.zmq_errno())
 
         value = ffi.buffer(C.zmq_msg_data(zmq_msg), int(C.zmq_msg_size(zmq_msg)))[:]
 


### PR DESCRIPTION
these changes are needed to use zmqpy with eventlet.green.zmq (provided you patch sys.modules['zmq'] = zmqpy)
